### PR TITLE
Adds CarbonStore

### DIFF
--- a/config/localizer.php
+++ b/config/localizer.php
@@ -2,12 +2,12 @@
 
 return [
 
-    /**
+    /*
      * The locales you wish to support.
      */
     'supported-locales' => [],
 
-    /**
+    /*
      * The detectors to use to find a matching locale.
      * These will be executed in the order that they are added to the array!
      */
@@ -19,34 +19,35 @@ return [
         CodeZero\Localizer\Detectors\AppDetector::class,
     ],
 
-    /**
+    /*
      * The stores to store the first matching locale in.
      */
     'stores' => [
         CodeZero\Localizer\Stores\SessionStore::class,
         CodeZero\Localizer\Stores\CookieStore::class,
         CodeZero\Localizer\Stores\AppStore::class,
+        CodeZero\Localizer\Stores\CarbonStore::class,
     ],
 
-    /**
+    /*
      * The index of the segment that has the locale,
      * when using the UrlDetector.
      */
     'url-segment' => 1,
 
-    /**
+    /*
      * The session key that holds the locale,
      * when using the SessionDetector and SessionStore.
      */
     'session-key' => 'locale',
 
-    /**
+    /*
      * The name of the cookie that holds the locale,
      * when using the CookieDetector and CookieStore.
      */
     'cookie-name' => 'locale',
 
-    /**
+    /*
      * The lifetime of the cookie that holds the locale,
      * when using the CookieStore.
      */

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,30 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Unit">
-            <directory suffix="Test.php">./tests/Unit</directory>
-        </testsuite>
-        <testsuite name="Feature">
-            <directory suffix="Test.php">./tests/Feature</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
-    <php>
-        <env name="APP_ENV" value="testing"/>
-        <env name="CACHE_DRIVER" value="array"/>
-        <env name="SESSION_DRIVER" value="array"/>
-        <env name="QUEUE_DRIVER" value="sync"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" bootstrap="vendor/autoload.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Unit">
+      <directory suffix="Test.php">./tests/Unit</directory>
+    </testsuite>
+    <testsuite name="Feature">
+      <directory suffix="Test.php">./tests/Feature</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <env name="APP_ENV" value="testing"/>
+    <env name="CACHE_DRIVER" value="array"/>
+    <env name="SESSION_DRIVER" value="array"/>
+    <env name="QUEUE_DRIVER" value="sync"/>
+  </php>
 </phpunit>

--- a/src/Localizer.php
+++ b/src/Localizer.php
@@ -49,7 +49,7 @@ class Localizer
     public function detect()
     {
         foreach ($this->detectors as $detector) {
-            $locales = (array) $this->getInstance($detector)->detect();
+            $locales = (array)$this->getInstance($detector)->detect();
 
             foreach ($locales as $locale) {
                 if ($this->isSupportedLocale($locale)) {

--- a/src/Stores/CarbonStore.php
+++ b/src/Stores/CarbonStore.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace CodeZero\Localizer\Stores;
+
+use Illuminate\Support\Carbon;
+
+class CarbonStore implements Store
+{
+    /**
+     * Store the given locale.
+     *
+     * @param string $locale
+     *
+     * @return void
+     */
+    public function store($locale)
+    {
+        Carbon::setLocale($locale);
+    }
+}

--- a/tests/Feature/SetLocaleTest.php
+++ b/tests/Feature/SetLocaleTest.php
@@ -5,6 +5,7 @@ namespace CodeZero\Localizer\Tests\Feature;
 use CodeZero\BrowserLocale\BrowserLocale;
 use CodeZero\Localizer\Middleware\SetLocale;
 use CodeZero\Localizer\Tests\TestCase;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Crypt;
@@ -36,6 +37,7 @@ class SetLocaleTest extends TestCase
         $this->setSessionLocale('fr');
         $this->setBrowserLocales('it');
         $this->setAppLocale('en');
+        $this->setCarbonLocale('es');
         $cookie = 'de';
 
         Route::get('nl/some/route', function () {
@@ -56,6 +58,7 @@ class SetLocaleTest extends TestCase
         $this->setSessionLocale('fr');
         $this->setBrowserLocales('it');
         $this->setAppLocale('en');
+        $this->setCarbonLocale('es');
         $cookie = 'de';
 
         Config::set('localizer.url-segment', 2);
@@ -78,6 +81,7 @@ class SetLocaleTest extends TestCase
         $this->setSessionLocale('fr');
         $this->setBrowserLocales('it');
         $this->setAppLocale('en');
+        $this->setCarbonLocale('es');
         $cookie = 'de';
 
         Route::get('some/route', function () {
@@ -98,6 +102,7 @@ class SetLocaleTest extends TestCase
         $this->setSessionLocale(null);
         $this->setBrowserLocales('it');
         $this->setAppLocale('en');
+        $this->setCarbonLocale('es');
         $cookie = 'de';
 
         Route::get('some/route', function () {
@@ -118,6 +123,7 @@ class SetLocaleTest extends TestCase
         $this->setSessionLocale(null);
         $this->setBrowserLocales('it');
         $this->setAppLocale('en');
+        $this->setCarbonLocale('es');
 
         Route::get('some/route', function () {
             return App::getLocale();
@@ -137,6 +143,7 @@ class SetLocaleTest extends TestCase
         $this->setSessionLocale(null);
         $this->setBrowserLocales('cs,it-IT;q=0.4,es;q=0.8');
         $this->setAppLocale('en');
+        $this->setCarbonLocale('es');
 
         Route::get('some/route', function () {
             return App::getLocale();
@@ -156,6 +163,7 @@ class SetLocaleTest extends TestCase
         $this->setSessionLocale(null);
         $this->setBrowserLocales(null);
         $this->setAppLocale('en');
+        $this->setCarbonLocale('es');
 
         Route::get('some/route', function () {
             return App::getLocale();
@@ -178,6 +186,20 @@ class SetLocaleTest extends TestCase
     protected function setAppLocale($locale)
     {
         App::setLocale($locale);
+
+        return $this;
+    }
+
+    /**
+     * Set the current carbon locale.
+     *
+     * @param string $locale
+     *
+     * @return $this
+     */
+    protected function setCarbonLocale($locale)
+    {
+        Carbon::setLocale($locale);
 
         return $this;
     }


### PR DESCRIPTION
This PR adds a `CarbonStore` which can be used to print human readable translated carbon string s. [here](https://carbon.nesbot.com/docs/#api-localization)